### PR TITLE
Fix for "Cannot use string offset as an array"

### DIFF
--- a/includes/search.form.inc
+++ b/includes/search.form.inc
@@ -37,7 +37,7 @@ function islandora_collection_search_form($form, &$form_state) {
     // searching otherwise get its parent.
     $qp = new IslandoraSolrQueryProcessor();
     $qp->buildQuery('*:*');
-    $qp->solrParams['fq'][] = format_string('!is_memberofcollection:"info:fedora/!pid" OR !is_member:"info:fedora/!pid"',
+    $qp->solrParams['fq'] = format_string('!is_memberofcollection:"info:fedora/!pid" OR !is_member:"info:fedora/!pid"',
       array(
         '!is_memberofcollection' => variable_get('islandora_solr_member_of_collection_field', 'RELS_EXT_isMemberOfCollection_uri_ms'),
         '!is_memberof' => variable_get('islandora_solr_member_of_field', 'RELS_EXT_isMemberOf_uri_ms'),

--- a/islandora_collection_search.module
+++ b/islandora_collection_search.module
@@ -125,6 +125,8 @@ function islandora_collection_search_form_islandora_solr_advanced_search_form_al
  */
 function islandora_collection_search_append_collection_pid($form, &$form_state) {
   if ($form_state['values']['collections'] != 'all') {
+    $redirect = $form_state['redirect'];
+    $form_state['redirect'] = array($redirect);
     $form_state['redirect'][1]['query']['cp'] = $form_state['values']['collections'];
   }
 }


### PR DESCRIPTION
We found this small modification necessary for using the advanced search form collection feature in our environment.
