### PR TITLE
replaces query string identifier "cp" with "pid"

### DIFF
--- a/includes/search.form.inc
+++ b/includes/search.form.inc
@@ -130,7 +130,7 @@ function islandora_collection_search_form_submit($form, &$form_state) {
   // Using edismax by default.
   $query = array('type' => 'edismax');
   if (isset($collection_select) && $collection_select !== 'all') {
-    $query['cp'] = $collection_select;
+    $query['pid'] = $collection_select;
   }
   drupal_goto('islandora/search/' . $search_string, array('query' => $query));
 }

--- a/islandora_collection_search.module
+++ b/islandora_collection_search.module
@@ -125,6 +125,6 @@ function islandora_collection_search_form_islandora_solr_advanced_search_form_al
  */
 function islandora_collection_search_append_collection_pid($form, &$form_state) {
   if ($form_state['values']['collections'] != 'all') {
-    $form_state['redirect'][1]['query']['cp'] = $form_state['values']['collections'];
+    $form_state['redirect'][1]['query']['pid'] = $form_state['values']['collections'];
   }
 }


### PR DESCRIPTION
Unless I'm mistaken, this fix was necessary for us to be able to use the collection search.