### PR TITLE
Fix issues with collection sharing and deleting

### DIFF
--- a/islandora_collection_search.module
+++ b/islandora_collection_search.module
@@ -55,13 +55,19 @@ function islandora_collection_search_islandora_solr_query($islandora_solr_query)
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
+ * Implements hook_form_alter().
  *
  * Adds a submit handler to any form that can potentially alter the object
  * hierarchy (e.g. changing parents, etc...).
  */
-function islandora_collection_search_form_islandora_basic_collection_migrate_children_form_alter(&$form, &$form_state) {
-  $form['#submit'][] = 'islandora_collection_search_migrate_children_form_submit';
+function islandora_collection_search_form_alter(&$form, &$form_state, $form_id) {
+  switch ($form_id) {
+    case 'islandora_basic_collection_migrate_children_form':
+    case 'islandora_basic_collection_share_children_form':
+    case 'islandora_basic_collection_delete_children_form':
+      $form['#submit'][] = 'islandora_collection_search_collection_form_submit';
+      break;
+  }
 }
 
 /**
@@ -89,10 +95,9 @@ function islandora_collection_search_menu() {
  * @param array $form_state
  *   Array representing the form state.
  */
-function islandora_collection_search_migrate_children_form_submit(&$form, &$form_state) {
+function islandora_collection_search_collection_form_submit(&$form, &$form_state) {
   // Grab the initial list of children that are being migrated from the form.
   $children = array_keys(array_filter($form_state['values']['children']));
-
   module_load_include('inc', 'islandora_collection_search', 'includes/batch');
   batch_set(islandora_collection_search_reindex_descendants_batch($children));
 }


### PR DESCRIPTION
## Issue

Items were going out of sync when items were shared between collections and deleted, perhaps this functionality was added after this module was created. This updates the module, so that a gsearch update is triggered in the case of a delete and a share, to keep the collection hierarchy in solr in sync correctly.

## Test Case

Enjoy the 🕶 ASCII art.

- Setup collection hierarchy like this:
```
collection1       collection2
           \
            \
         collection3
              |
              |
            item1
```

- Test that `item1` has the correct hierarchy indexed in solr.
  - `collection3`
  - `collection1`

- From `collection1` share `collection3` with `collection2`.

```
collection1       collection2
           \     /
            \   /
         collection3
              |
              |
            item1
```

- Test that `item1` has the correct hierarchy indexed in solr.
  - `collection3`
  - `collection1`
  - `collection2`

- From `collection1` delete `collection3`.

```
collection1       collection2
                 /
                /
         collection3
              |
              |
            item1
```

- Test that `item1` has the correct hierarchy indexed in solr.
  - `collection3`
  - `collection2`

Without patch you should find:  👎 
After patch you should find:  🎉 🤘 