### PR TITLE
Update php version for D8

### DIFF
--- a/islandora_collection_search.info.yml
+++ b/islandora_collection_search.info.yml
@@ -7,4 +7,4 @@ dependencies:
   islandora_solr: ':islandora_solr'
   islandora_basic_collection: ':islandora_basic_collection'
 type: module
-php: '5.5.9'
+php: '7.2'


### PR DESCRIPTION
php 5 support is being dropped:
[Drupal docs](https://www.drupal.org/docs/8/system-requirements/php-requirements)