### PR TITLE
Invalid argument for foreach

### DIFF
--- a/includes/search.form.inc
+++ b/includes/search.form.inc
@@ -151,7 +151,7 @@ function islandora_collection_search_get_collection_pid() {
     variable_get('islandora_solr_member_of_field', 'RELS_EXT_isMemberOf_uri_ms'),
   );
   // Find rels ext in parameters.
-  if (isset($params['f'])) {
+  if (isset($params['f']) && is_array($params['f'])) {
     foreach ($params['f'] as $filter) {
       $filter_arr = explode(':', $filter);
       foreach ($rels_ext as $rels) {
@@ -163,7 +163,7 @@ function islandora_collection_search_get_collection_pid() {
     }
   }
   $hidden_match = array();
-  if (preg_match('@.*:"(?:info\\\:fedora\\\/)?(.*)"@', $hidden_filter, $hidden_match)) {
+  if (isset($hidden_filter) && preg_match('@.*:"(?:info\\\:fedora\\\/)?(.*)"@', $hidden_filter, $hidden_match)) {
     $pid = str_replace('\\', '', $hidden_match[1]);
     return $pid;
   }


### PR DESCRIPTION
We see a lot of the following errors in our recent log messages:
Warning: Invalid argument supplied for foreach() in islandora_collection_search_get_collection_pid() (line 155 of /var/www/html/drupal7/sites/all/modules/islandora_collection_search/includes/search.form.inc).

This might be due to invalid params for the url, but it would be better to handle these kinds of wrong user input more elegant.

This PR checks the type of the parameter before using it. Also it checks if a deducted value is actually set before using it, because this may lead to warning in future versions.

Related to incident 19326